### PR TITLE
Remove more references to Shipment#address

### DIFF
--- a/core/spec/lib/tasks/migrations/copy_shipped_shipments_to_cartons_spec.rb
+++ b/core/spec/lib/tasks/migrations/copy_shipped_shipments_to_cartons_spec.rb
@@ -52,7 +52,7 @@ describe 'spree:migrations:copy_shipped_shipments_to_cartons' do
 
       expect(carton.number).to eq "C#{shipped_shipment.number}"
       expect(carton.stock_location).to eq shipped_shipment.stock_location
-      expect(carton.address).to eq shipped_shipment.address
+      expect(carton.address).to eq shipped_shipment.order.ship_address
       expect(carton.shipping_method).to eq shipped_shipment.shipping_method
       expect(carton.tracking).to eq shipped_shipment.tracking
       expect(carton.shipped_at).to eq shipped_shipment.shipped_at

--- a/core/spec/models/spree/stock/coordinator_spec.rb
+++ b/core/spec/models/spree/stock/coordinator_spec.rb
@@ -26,11 +26,6 @@ module Spree
           expect(subject.shipments.size).to eq(1)
         end
 
-        it "puts the order's ship address on the shipments" do
-          shipments = subject.shipments
-          expect(shipments.map(&:address)).to eq [order.ship_address]
-        end
-
         it "builds a shipment for all active stock locations" do
           subject.shipments.count == StockLocation.count
         end


### PR DESCRIPTION
@metade here are a few more references to Shipment#address that I noticed while working on updating Solidus
