### PR TITLE
Make last names optional on Spree::Address

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -5,7 +5,7 @@ module Spree
     belongs_to :country, class_name: "Spree::Country"
     belongs_to :state, class_name: "Spree::State"
 
-    validates :firstname, :lastname, :address1, :city, :country_id, presence: true
+    validates :firstname, :address1, :city, :country_id, presence: true
     validates :zipcode, presence: true, if: :require_zipcode?
     validates :phone, presence: true, if: :require_phone?
 

--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -11,7 +11,7 @@ FactoryGirl.define do
     end
 
     firstname 'John'
-    lastname 'Doe'
+    lastname nil
     company 'Company'
     address1 '10 Lovely Street'
     address2 'Northwest'


### PR DESCRIPTION
(See Solidus PR 1369)

Amazon Payments doesn't require two names, which breaks this
validation. It's hard to remove an ActiveRecord validation at the
app level.
