### PR TITLE
Prefer keeping order.order_promotions relationship up to date

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -104,10 +104,11 @@ module Spree
       action_taken = results.include?(true)
 
       # connect to the order
-      order_promotions.find_or_create_by!(
-        order_id: order.id,
-        promotion_code_id: promotion_code.try!(:id)
+      order.order_promotions.find_or_create_by!(
+        promotion: self,
+        promotion_code: promotion_code,
       )
+      order.promotions.reset
 
       Spree::Config.promotions_to_remove_from_order_class.new(order).
         promotions_to_remove.


### PR DESCRIPTION
_Cherry-picked from Solidus PR 1439_

Prefer keeping `Order#order_promotions` up to date instead of
`Promotion#order_promotions`.  The former is more likely to be
important.

Conflicts:
    core/app/models/spree/promotion.rb
