### PR TITLE
Fix FreeShipping promos that have codes

### DIFF
--- a/frontend/spec/features/free_shipping_promotions_spec.rb
+++ b/frontend/spec/features/free_shipping_promotions_spec.rb
@@ -15,15 +15,14 @@ describe "Free shipping promotions", type: :feature, js: true do
   let!(:payment_method) { create(:check_payment_method) }
   let!(:product) { create(:product, name: "RoR Mug", price: 20) }
   let!(:promotion) do
-    promotion = Spree::Promotion.create!(name: "Free Shipping",
-                                         starts_at: 1.day.ago,
-                                         expires_at: 1.day.from_now)
-
-    action = Spree::Promotion::Actions::FreeShipping.new
-    action.promotion = promotion
-    action.save
-
-    promotion.reload # so that promotion.actions is available
+    create(
+      :promotion,
+      apply_automatically: true,
+      promotion_actions: [Spree::Promotion::Actions::FreeShipping.new],
+      name: "Free Shipping",
+      starts_at: 1.day.ago,
+      expires_at: 1.day.from_now,
+    )
   end
 
   context "free shipping promotion automatically applied" do


### PR DESCRIPTION
*Cherry-picked from Solidus PR 1392.*  No changes made or conflicts
resolved.

This commit:
https://github.com/solidusio/solidus/commit/4a62eca#diff-d7fd5424af325ba4827da883ac185ded
broke this fix:
https://github.com/solidusio/solidus/commit/7b50d73
because we stopped looking for promotions with codes.  So if you apply
a free shipping promo to your order and then go backward in the order
state machine (and have your shipments regenerated) you won't get your
promotion re-applied when you move forward in the state machine again.

This also updates FreeShipping promotions to use the recently-added
apply_automatically promotion flag, rather than looking for the
absence of codes and paths.