### PR TITLE
Add missing index to spree_payments.number

### DIFF
--- a/core/db/migrate/20161129035810_add_index_to_spree_payments_number.rb
+++ b/core/db/migrate/20161129035810_add_index_to_spree_payments_number.rb
@@ -1,0 +1,5 @@
+class AddIndexToSpreePaymentsNumber < ActiveRecord::Migration
+  def change
+    add_index 'spree_payments', ['number'], unique: true
+  end
+end


### PR DESCRIPTION
*Cherry picked from Solidus PR 1625*

We ensure uniqueness and query by number inside of
Payment#set_unique_identifier.  This should have an index.