### PR TITLE
Optimize free shipping handler

### DIFF
--- a/frontend/spec/features/free_shipping_promotions_spec.rb
+++ b/frontend/spec/features/free_shipping_promotions_spec.rb
@@ -15,15 +15,14 @@ describe "Free shipping promotions", type: :feature, js: true do
   let!(:payment_method) { create(:check_payment_method) }
   let!(:product) { create(:product, name: "RoR Mug", price: 20) }
   let!(:promotion) do
-    promotion = Spree::Promotion.create!(name: "Free Shipping",
-                                         starts_at: 1.day.ago,
-                                         expires_at: 1.day.from_now)
-
-    action = Spree::Promotion::Actions::FreeShipping.new
-    action.promotion = promotion
-    action.save
-
-    promotion.reload # so that promotion.actions is available
+    create(
+      :promotion,
+      apply_automatically: true,
+      promotion_actions: [Spree::Promotion::Actions::FreeShipping.new],
+      name: "Free Shipping",
+      starts_at: 1.day.ago,
+      expires_at: 1.day.from_now,
+    )
   end
 
   context "free shipping promotion automatically applied" do


### PR DESCRIPTION
See individual commits.

The first is already merged into Solidus and the second has a pending pull request.

This should allow us to turn the free shipping promo code back on (see https://github.com/Lostmyname/eagle/pull/4820).  I'm not sure but I think I feel safer merging this than not merging it and leaving that code disabled.

Note: This got upstreamed to Solidus in https://github.com/solidusio/solidus/pull/1622