### PR TITLE
Remove deprecated Variant#currency

### DIFF
--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -15,9 +15,8 @@ module Spree
       default_price || build_default_price(Spree::Config.default_pricing_options.desired_attributes)
     end
 
-    delegate :display_price, :display_amount, :price, :currency, to: :find_or_build_default_price
-    delegate :price=, :currency=, to: :find_or_build_default_price
-    deprecate :currency=, :currency, deprecator: Spree::Deprecation
+    delegate :display_price, :display_amount, :price, to: :find_or_build_default_price
+    delegate :price=, to: :find_or_build_default_price
 
     def has_default_price?
       !default_price.nil?

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -178,14 +178,6 @@ describe Spree::Variant, type: :model do
     end
   end
 
-  context "#currency" do
-    it "returns the globally configured currency" do
-      Spree::Deprecation.silence do
-        expect(variant.currency).to eql "USD"
-      end
-    end
-  end
-
   context "#display_amount" do
     it "returns a Spree::Money" do
       variant.price = 21.22


### PR DESCRIPTION
*Cherry-picked from Solidus PR 1661. Merged in Solidus 2.1.*

Pulling this in for the removal of the `variant.currency=` method.  This doesn't really work because it changes the currency of the `default_price` record, but this means that the updated `default_price` object for the variant is no longer actually the default price because being the default price is dependent on having a currency that matches `Spree::Config.currency` so the in-memory `default_price` immediately becomes incorrect.