### PR TITLE
Make Address.find_all_by_name_or_abbr case-insensitive

### DIFF
--- a/core/app/models/spree/state.rb
+++ b/core/app/models/spree/state.rb
@@ -6,7 +6,7 @@ module Spree
     validates :country, :name, presence: true
 
     def self.find_all_by_name_or_abbr(name_or_abbr)
-      where('name = ? OR abbr = ?', name_or_abbr, name_or_abbr)
+      where('lower(name) = lower(:name_or_abbr) OR lower(abbr) = lower(:name_or_abbr)', name_or_abbr: name_or_abbr)
     end
 
     # table of { country.id => [ state.id , state.name ] }, arrays sorted by name

--- a/core/spec/models/spree/state_spec.rb
+++ b/core/spec/models/spree/state_spec.rb
@@ -1,10 +1,37 @@
 require 'spec_helper'
 
 describe Spree::State, type: :model do
-  it "can find a state by name or abbr" do
-    state = create(:state, name: "California", abbr: "CA")
-    expect(Spree::State.find_all_by_name_or_abbr("California")).to include(state)
-    expect(Spree::State.find_all_by_name_or_abbr("CA")).to include(state)
+  describe '.find_all_by_name_or_abbr' do
+    subject do
+      Spree::State.find_all_by_name_or_abbr(search_term)
+    end
+
+    let!(:state) { create(:state, name: "California", abbr: "CA") }
+
+    context 'by invalid term' do
+      let(:search_term) { 'NonExistent' }
+      it { is_expected.to be_empty }
+    end
+
+    context 'by name' do
+      let(:search_term) { 'California' }
+      it { is_expected.to include(state) }
+    end
+
+    context 'by abbr' do
+      let(:search_term) { 'California' }
+      it { is_expected.to include(state) }
+    end
+
+    context 'by case-insensitive abbr' do
+      let(:search_term) { 'CaLiFoRnIa' }
+      it { is_expected.to include(state) }
+    end
+
+    context 'by case-insensitive abbr' do
+      let(:search_term) { 'cA' }
+      it { is_expected.to include(state) }
+    end
   end
 
   it "can find all states group by country id" do


### PR DESCRIPTION
*Cherry-picked from Solidus PR 2043*

This is helpful when importing data from third parties. E.g. PayPal.