### PR TITLE
Enable custom shipping promotions via config.spree.promotions.shipping_actions

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -520,10 +520,11 @@ module Spree
       end
     end
 
-    def apply_free_shipping_promotions
-      Spree::PromotionHandler::FreeShipping.new(self).activate
+    def apply_shipping_promotions
+      Spree::PromotionHandler::Shipping.new(self).activate
       update!
     end
+    deprecate apply_free_shipping_promotions: :apply_shipping_promotions, deprecator: Spree::Deprecation
 
     # Clean shipments and make order back to address state
     #

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -98,7 +98,7 @@ module Spree
                 before_transition to: :delivery, do: :create_proposed_shipments
                 before_transition to: :delivery, do: :ensure_available_shipping_rates
                 before_transition to: :delivery, do: :set_shipments_cost
-                before_transition from: :delivery, do: :apply_free_shipping_promotions
+                before_transition from: :delivery, do: :apply_shipping_promotions
               end
 
               before_transition to: :resumed, do: :ensure_line_item_variants_are_not_deleted

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -8,7 +8,8 @@ module Spree
 
     belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_actions
 
-    scope :of_type, ->(t) { where(type: t.to_s) }
+    scope :of_type, ->(t) { where(type: Array.wrap(t).map(&:to_s)) }
+    scope :shipping, -> { of_type(Rails.application.config.spree.promotions.shipping_actions.to_a) }
 
     # Updates the state of the order or performs some other action depending on
     # the subclass options will contain the payload from the event that

--- a/core/app/models/spree/promotion_handler/shipping.rb
+++ b/core/app/models/spree/promotion_handler/shipping.rb
@@ -1,7 +1,7 @@
 module Spree
   module PromotionHandler
     # Used for activating promotions with shipping rules
-    class FreeShipping
+    class Shipping
       attr_reader :order
       attr_accessor :error, :success
 
@@ -29,7 +29,7 @@ module Spree
       end
 
       def automatic_promotions
-        @automatic_promotions ||= active_free_shipping_promotions.
+        @automatic_promotions ||= active_shipping_promotions.
           where(apply_automatically: true).
           to_a.
           uniq
@@ -39,20 +39,16 @@ module Spree
         @connected_promotions ||= order.order_promotions.
           joins(:promotion).
           includes(:promotion).
-          merge(active_free_shipping_promotions).
+          merge(active_shipping_promotions).
           to_a.
           uniq
       end
 
-      def active_free_shipping_promotions
+      def active_shipping_promotions
         Spree::Promotion.all.
           active.
           joins(:promotion_actions).
-          merge(
-            Spree::PromotionAction.of_type(
-              Spree::Promotion::Actions::FreeShipping
-            )
-          )
+          merge(Spree::PromotionAction.shipping)
       end
     end
   end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -109,6 +109,12 @@ module Spree
         ]
       end
 
+      initializer 'spree.promo.register.promotions.shipping_actions', before: :load_config_initializers do |app|
+        app.config.spree.promotions.shipping_actions = %w[
+          Spree::Promotion::Actions::FreeShipping
+        ]
+      end
+
       # filter sensitive information during logging
       initializer "spree.params.filter", before: :load_config_initializers do |app|
         app.config.filter_parameters += [

--- a/core/lib/spree/promo/environment.rb
+++ b/core/lib/spree/promo/environment.rb
@@ -5,6 +5,7 @@ module Spree
 
       add_class_set :rules
       add_class_set :actions
+      add_class_set :shipping_actions
     end
   end
 end

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -285,12 +285,12 @@ describe Spree::Order, type: :model do
       before do
         order.ship_address = ship_address
         order.state = 'delivery'
-        allow(order).to receive(:apply_free_shipping_promotions)
+        allow(order).to receive(:apply_shipping_promotions)
         allow(order).to receive(:ensure_available_shipping_rates) { true }
       end
 
       it "attempts to apply free shipping promotions" do
-        expect(order).to receive(:apply_free_shipping_promotions)
+        expect(order).to receive(:apply_shipping_promotions)
         order.next!
       end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -605,15 +605,15 @@ describe Spree::Order, type: :model do
     end
   end
 
-  context "#apply_free_shipping_promotions" do
-    it "calls out to the FreeShipping promotion handler" do
-      expect_any_instance_of(Spree::PromotionHandler::FreeShipping).to(
+  context "#apply_shipping_promotions" do
+    it "calls out to the Shipping promotion handler" do
+      expect_any_instance_of(Spree::PromotionHandler::Shipping).to(
         receive(:activate)
       ).and_call_original
 
       expect(order.updater).to receive(:update).and_call_original
 
-      order.apply_free_shipping_promotions
+      order.apply_shipping_promotions
     end
   end
 


### PR DESCRIPTION
*Cherry-picked with conflicts from Solidus PR 2135*

This updates the shipping promotion handler so that it will look for promotion
action types via `Rails.application.config.spree.promotions.shipping_actions`,
instead of only looking for actions of type
`Spree::Promotion::Actions::FreeShipping`.

This should allow applications to create their own shipping promotion actions.