### PR TITLE
Add `dependent: :destroy` for ShippingMethodZones join model

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -16,7 +16,7 @@ module Spree
     has_many :shipments, through: :shipping_rates
     has_many :cartons, inverse_of: :shipping_method
 
-    has_many :shipping_method_zones
+    has_many :shipping_method_zones, dependent: :destroy
     has_many :zones, through: :shipping_method_zones
 
     belongs_to :tax_category, -> { with_deleted }, class_name: 'Spree::TaxCategory'

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -8,7 +8,7 @@ module Spree
       has_many :states, source_type: "Spree::State"
     end
 
-    has_many :shipping_method_zones
+    has_many :shipping_method_zones, dependent: :destroy
     has_many :shipping_methods, through: :shipping_method_zones
 
     validates :name, presence: true, uniqueness: { allow_blank: true }


### PR DESCRIPTION
*Cherry-picked from Solidus PR 2175 on Solidus 2.4*

We were getting null errors when a zone was deleted.

NOTE: I'll also add this to the Solidus 2.2 branch also after merging.