### PR TITLE
[Solidus 2.4? PR 2188] Update Solidus to work correctly with non-promotion line-level adjustments

### DIFF
--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -12,7 +12,7 @@ module Spree
         rate.tax_categories.include?(line_item.tax_category)
       end
 
-      line_items_total = matched_line_items.sum(&:discounted_amount)
+      line_items_total = matched_line_items.sum(&:final_amount_without_additional_tax)
       if rate.included_in_price
         order_tax_amount = round_to_two_places(line_items_total - ( line_items_total / (1 + rate.amount) ) )
         refund_if_necessary(order_tax_amount, order.tax_address)
@@ -26,7 +26,7 @@ module Spree
       if rate.included_in_price
         deduced_total_by_rate(item, rate)
       else
-        round_to_two_places(item.discounted_amount * rate.amount)
+        round_to_two_places(item.final_amount_without_additional_tax * rate.amount)
       end
     end
 
@@ -45,7 +45,7 @@ module Spree
     end
 
     def deduced_total_by_rate(item, rate)
-      unrounded_net_amount = item.discounted_amount / (1 + sum_of_included_tax_rates(item))
+      unrounded_net_amount = item.final_amount_without_additional_tax / (1 + sum_of_included_tax_rates(item))
       refund_if_necessary(
         round_to_two_places(unrounded_net_amount * rate.amount),
         item.order.tax_address

--- a/core/app/models/spree/calculator/returns/default_refund_amount.rb
+++ b/core/app/models/spree/calculator/returns/default_refund_amount.rb
@@ -16,12 +16,12 @@ module Spree
       end
 
       def weighted_line_item_amount(inventory_unit)
-        inventory_unit.line_item.discounted_amount * percentage_of_line_item(inventory_unit)
+        inventory_unit.line_item.final_amount_without_additional_tax * percentage_of_line_item(inventory_unit)
       end
 
       def percentage_of_order_total(inventory_unit)
-        return 0.0 if inventory_unit.order.discounted_item_amount.zero?
-        weighted_line_item_amount(inventory_unit) / inventory_unit.order.discounted_item_amount
+        return 0.0 if inventory_unit.order.final_item_amount_without_additional_tax.zero?
+        weighted_line_item_amount(inventory_unit) / inventory_unit.order.final_item_amount_without_additional_tax
       end
 
       def percentage_of_line_item(inventory_unit)

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -57,6 +57,13 @@ module Spree
     def discounted_amount
       amount + promo_total
     end
+    deprecate discounted_amount: :final_amount_without_additional_tax, deprecator: Spree::Deprecation
+
+    # @return [BigDecimal] the amount of this item, taking into consideration
+    #   all non-tax adjustments.
+    def final_amount_without_additional_tax
+      amount + adjustments.reject(&:tax?).sum(&:amount)
+    end
 
     # @return [BigDecimal] the amount of this line item, taking into
     #   consideration all its adjustments.
@@ -68,13 +75,16 @@ module Spree
     # @return [BigDecimal] the amount of this line item before included tax
     # @note just like `amount`, this does not include any additional tax
     def pre_tax_amount
-      discounted_amount - included_tax_total
+      final_amount_without_additional_tax - included_tax_total
     end
 
     extend Spree::DisplayMoney
     money_methods :amount, :discounted_amount, :final_amount, :pre_tax_amount, :price,
-                  :included_tax_total, :additional_tax_total
+                  :included_tax_total, :additional_tax_total,
+                  :final_amount_without_additional_tax
+    deprecate display_discounted_amount: :display_final_amount_without_additional_tax, deprecator: Spree::Deprecation
     alias discounted_money display_discounted_amount
+    deprecate discounted_money: :display_final_amount_without_additional_tax, deprecator: Spree::Deprecation
 
     # @return [Spree::Money] the price of this line item
     alias money_price display_price

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -62,7 +62,7 @@ module Spree
     # @return [BigDecimal] the amount of this item, taking into consideration
     #   all non-tax adjustments.
     def final_amount_without_additional_tax
-      amount + adjustments.reject(&:tax?).sum(&:amount)
+      amount + adjustments.select { |a| !a.tax? && a.eligible? }.sum(&:amount)
     end
 
     # @return [BigDecimal] the amount of this line item, taking into

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -178,6 +178,11 @@ module Spree
     def discounted_item_amount
       line_items.to_a.sum(&:discounted_amount)
     end
+    deprecate discounted_item_amount: :final_item_amount_without_additional_tax, deprecator: Spree::Deprecation
+
+    def final_item_amount_without_additional_tax
+      line_items.to_a.sum(&:final_amount_without_additional_tax)
+    end
 
     def currency
       self[:currency] || Spree::Config[:currency]

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -53,7 +53,7 @@ module Spree
     end
 
     def refundable_amount
-      order.discounted_item_amount + order.promo_total
+      order.final_item_amount_without_additional_tax + order.promo_total
     end
 
     def customer_returned_items?

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -89,7 +89,11 @@ module Spree
     end
 
     extend DisplayMoney
-    money_methods :cost, :amount, :discounted_cost, :final_price, :item_cost
+    money_methods(
+      :cost, :amount, :discounted_cost, :final_price, :item_cost,
+      :final_amount_without_additional_tax,
+    )
+    deprecate display_discounted_cost: :display_final_amount_without_additional_tax, deprecator: Spree::Deprecation
     alias_attribute :amount, :cost
 
     def add_shipping_method(shipping_method, selected = false)
@@ -115,10 +119,14 @@ module Spree
     def discounted_cost
       cost + promo_total
     end
+    deprecate discounted_cost: :final_amount_without_additional_tax, deprecator: Spree::Deprecation
     alias discounted_amount discounted_cost
+    deprecate discounted_amount: :final_amount_without_additional_tax, deprecator: Spree::Deprecation
 
-    def editable_by?(_user)
-      !shipped?
+    # @return [BigDecimal] the amount of this item, taking into consideration
+    #   all non-tax adjustments.
+    def final_amount_without_additional_tax
+      amount + adjustments.reject(&:tax?).sum(&:amount)
     end
 
     def final_price
@@ -127,6 +135,10 @@ module Spree
 
     def final_price_with_items
       item_cost + final_price
+    end
+
+    def editable_by?(_user)
+      !shipped?
     end
 
     # Decrement the stock counts for all pending inventory units in this
@@ -163,7 +175,7 @@ module Spree
     end
 
     def pre_tax_amount
-      discounted_amount - included_tax_total
+      final_amount_without_additional_tax - included_tax_total
     end
 
     def ready_or_pending?

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -126,7 +126,7 @@ module Spree
     # @return [BigDecimal] the amount of this item, taking into consideration
     #   all non-tax adjustments.
     def final_amount_without_additional_tax
-      amount + adjustments.reject(&:tax?).sum(&:amount)
+      amount + adjustments.select { |a| !a.tax? && a.eligible? }.sum(&:amount)
     end
 
     def final_price

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -17,6 +17,8 @@ module Spree
     alias_attribute :amount, :cost
 
     alias_method :discounted_amount, :amount
+    deprecate discounted_amount: :final_amount_without_additional_tax, deprecator: Spree::Deprecation
+    alias_method :final_amount_without_additional_tax, :amount
 
     extend DisplayMoney
     money_methods :amount

--- a/core/spec/lib/spree/core/price_migrator_spec.rb
+++ b/core/spec/lib/spree/core/price_migrator_spec.rb
@@ -195,7 +195,7 @@ describe Spree::PriceMigrator do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(18.69)
+          expect(line_item.final_amount_without_additional_tax - line_item.included_tax_total).to eq(18.69)
         end
       end
 
@@ -215,7 +215,7 @@ describe Spree::PriceMigrator do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(25.21)
+          expect(line_item.final_amount_without_additional_tax - line_item.included_tax_total).to eq(25.21)
         end
       end
 
@@ -235,7 +235,7 @@ describe Spree::PriceMigrator do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(8.40)
+          expect(line_item.final_amount_without_additional_tax - line_item.included_tax_total).to eq(8.40)
         end
       end
     end
@@ -269,7 +269,7 @@ describe Spree::PriceMigrator do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(18.69)
+          expect(line_item.final_amount_without_additional_tax - line_item.included_tax_total).to eq(18.69)
         end
       end
     end
@@ -302,7 +302,7 @@ describe Spree::PriceMigrator do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(18.69)
+          expect(line_item.final_amount_without_additional_tax - line_item.included_tax_total).to eq(18.69)
         end
       end
 
@@ -326,7 +326,7 @@ describe Spree::PriceMigrator do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(25.21)
+          expect(line_item.final_amount_without_additional_tax - line_item.included_tax_total).to eq(25.21)
         end
       end
 
@@ -350,7 +350,7 @@ describe Spree::PriceMigrator do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(8.40)
+          expect(line_item.final_amount_without_additional_tax - line_item.included_tax_total).to eq(8.40)
         end
       end
     end

--- a/core/spec/models/spree/calculator/default_tax_spec.rb
+++ b/core/spec/models/spree/calculator/default_tax_spec.rb
@@ -92,7 +92,14 @@ describe Spree::Calculator::DefaultTax, type: :model do
   end
 
   shared_examples_for 'computing any item' do
-    let(:promo_total) { 0 }
+    let(:adjustment_total) { 0 }
+    let(:adjustments) do
+      if adjustment_total.zero?
+        []
+      else
+       [Spree::Adjustment.new(included: false, source: nil, amount: adjustment_total)]
+      end
+    end
     let(:order) { build_stubbed(:order, ship_address: address) }
 
     context "when tax is included in price" do
@@ -103,10 +110,10 @@ describe Spree::Calculator::DefaultTax, type: :model do
           expect(calculator.compute(item)).to eql 1.43
         end
 
-        context "when line item is discounted" do
-          let(:promo_total) { -1 }
+        context "when line item is adjusted" do
+          let(:adjustment_total) { -1 }
 
-          it "should be equal to the item's discounted total * rate" do
+          it "should be equal to the item's adjusted total * rate" do
             expect(calculator.compute(item)).to eql 1.38
           end
         end
@@ -129,8 +136,8 @@ describe Spree::Calculator::DefaultTax, type: :model do
     end
 
     context "when tax is not included in price" do
-      context "when the line item is discounted" do
-        let(:promo_total) { -1 }
+      context "when the item has an adjustment" do
+        let(:adjustment_total) { -1 }
 
         it "should be equal to the item's pre-tax total * rate" do
           expect(calculator.compute(item)).to eq(1.45)
@@ -151,7 +158,7 @@ describe Spree::Calculator::DefaultTax, type: :model do
         :line_item,
         price: 10,
         quantity: 3,
-        promo_total: promo_total,
+        adjustments: adjustments,
         order: order,
         tax_category: tax_category
       )
@@ -180,7 +187,7 @@ describe Spree::Calculator::DefaultTax, type: :model do
       build_stubbed(
         :shipment,
         cost: 30,
-        promo_total: promo_total,
+        adjustments: adjustments,
         order: order,
         shipping_rates: [shipping_rate]
       )
@@ -205,12 +212,12 @@ describe Spree::Calculator::DefaultTax, type: :model do
     end
 
     let(:item) do
-      # cost and discounted_amount for shipping rates are the same as they
-      # can not be discounted. for the sake of passing tests, the cost is
+      # cost and adjusted amount for shipping rates are the same as they
+      # can not be adjusted. for the sake of passing tests, the cost is
       # adjusted here.
       build_stubbed(
         :shipping_rate,
-        cost: 30 + promo_total,
+        cost: 30 + adjustment_total,
         selected: true,
         shipping_method: shipping_method,
         shipment: shipment

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -93,19 +93,35 @@ describe Spree::LineItem, type: :model do
     end
   end
 
-  describe '.discounted_amount' do
+  # TODO: Remove this spec after the method has been removed.
+  describe '#discounted_amount' do
     it "returns the amount minus any discounts" do
       line_item.price = 10
       line_item.quantity = 2
       line_item.promo_total = -5
-      expect(line_item.discounted_amount).to eq(15)
+      expect(Spree::Deprecation.silence { line_item.discounted_amount }).to eq(15)
     end
   end
 
+  # TODO: Remove this spec after the method has been removed.
   describe "#discounted_money" do
     it "should return a money object with the discounted amount" do
-      expect(line_item.discounted_amount).to eq(10.00)
-      expect(line_item.discounted_money.to_s).to eq "$10.00"
+      expect(Spree::Deprecation.silence { line_item.discounted_amount }).to eq(10.00)
+      expect(Spree::Deprecation.silence { line_item.discounted_money.to_s }).to eq "$10.00"
+    end
+  end
+
+  describe '#final_amount_without_additional_tax' do
+    before do
+      line_item.update!(price: 10, quantity: 2)
+    end
+    let!(:admin_adjustment) { create(:adjustment, adjustable: line_item, order: line_item.order, amount: -1, source: nil) }
+    let!(:promo_adjustment) { create(:adjustment, adjustable: line_item, order: line_item.order, amount: -2, source: promo_action) }
+    let(:promo_action) { promo.actions[0] }
+    let(:promo) { create(:promotion, :with_line_item_adjustment) }
+
+    it 'returns the amount minus any adjustments' do
+      expect(line_item.final_amount_without_additional_tax).to eq(20 - 1 - 2)
     end
   end
 

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -117,6 +117,7 @@ describe Spree::LineItem, type: :model do
     end
     let!(:admin_adjustment) { create(:adjustment, adjustable: line_item, order: line_item.order, amount: -1, source: nil) }
     let!(:promo_adjustment) { create(:adjustment, adjustable: line_item, order: line_item.order, amount: -2, source: promo_action) }
+    let!(:ineligible_promo_adjustment) { create(:adjustment, eligible: false, adjustable: line_item, order: line_item.order, amount: -4, source: promo_action) }
     let(:promo_action) { promo.actions[0] }
     let(:promo) { create(:promotion, :with_line_item_adjustment) }
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -152,6 +152,7 @@ describe Spree::Shipment, type: :model do
     end
     let!(:admin_adjustment) { create(:adjustment, adjustable: shipment, order: shipment.order, amount: -1, source: nil) }
     let!(:promo_adjustment) { create(:adjustment, adjustable: shipment, order: shipment.order, amount: -2, source: promo_action) }
+    let!(:ineligible_promo_adjustment) { create(:adjustment, eligible: false, adjustable: shipment, order: shipment.order, amount: -4, source: promo_action) }
     let(:promo_action) { promo.actions[0] }
     let(:promo) { create(:promotion, :with_line_item_adjustment) }
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -143,7 +143,21 @@ describe Spree::Shipment, type: :model do
     shipment = create(:shipment)
     shipment.cost = 10
     shipment.promo_total = -1
-    expect(shipment.discounted_cost).to eq(9)
+    expect(Spree::Deprecation.silence { shipment.discounted_cost }).to eq(9)
+  end
+
+  describe '#final_amount_without_additional_tax' do
+    before do
+      shipment.update_attributes!(cost: 10)
+    end
+    let!(:admin_adjustment) { create(:adjustment, adjustable: shipment, order: shipment.order, amount: -1, source: nil) }
+    let!(:promo_adjustment) { create(:adjustment, adjustable: shipment, order: shipment.order, amount: -2, source: promo_action) }
+    let(:promo_action) { promo.actions[0] }
+    let(:promo) { create(:promotion, :with_line_item_adjustment) }
+
+    it 'returns the amount minus any adjustments' do
+      expect(shipment.final_amount_without_additional_tax).to eq(10 - 1 - 2)
+    end
   end
 
   it "#tax_total with included taxes" do

--- a/core/spec/models/spree/tax/taxation_integration_spec.rb
+++ b/core/spec/models/spree/tax/taxation_integration_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(18.69)
+          expect(line_item.final_amount_without_additional_tax - line_item.included_tax_total).to eq(18.69)
         end
       end
 
@@ -321,7 +321,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(25.21)
+          expect(line_item.final_amount_without_additional_tax - line_item.included_tax_total).to eq(25.21)
         end
       end
 
@@ -359,7 +359,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(8.40)
+          expect(line_item.final_amount_without_additional_tax - line_item.included_tax_total).to eq(8.40)
         end
       end
 
@@ -410,7 +410,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(18.69)
+          expect(line_item.final_amount_without_additional_tax - line_item.included_tax_total).to eq(18.69)
         end
       end
     end
@@ -443,7 +443,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(18.69)
+          expect(line_item.final_amount_without_additional_tax - line_item.included_tax_total).to eq(18.69)
         end
 
         context 'an order with a book and a shipment' do
@@ -485,7 +485,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(25.21)
+          expect(line_item.final_amount_without_additional_tax - line_item.included_tax_total).to eq(25.21)
         end
 
         context 'an order with a sweater and a shipment' do
@@ -527,7 +527,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(8.40)
+          expect(line_item.final_amount_without_additional_tax - line_item.included_tax_total).to eq(8.40)
         end
       end
 


### PR DESCRIPTION
**Cherry-picked from Solidus PR 2188.**

In Solidus PR 1933 we starting allowing allow non-promotion adjustments on line items
and shipments.  However, we didn't update some other important code (including
the DefaultTax calculator) to consider these adjustments.

This commit:

- Adds a `final_amount_without_additional_tax` method on LineItem, Shipment, and
ShippingRate.
- Updates Calculator::DefaultTax to use this method when calculating taxes.
- Updates all other code inside Solidus to use this method.
- Deprecates the old `discounted_amount` methods.